### PR TITLE
Change Rx to a peer dependency instead of an outright dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "istanbul": "0.4.2",
     "jshint": "2.9.1",
     "lintspaces-cli": "0.1.1",
-    "mocha": "2.4.5"
+    "mocha": "2.4.5",
+    "rx": ">=4.0.7 <5"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "url": "https://github.com/tangledfruit/rx-to-async-iterator/issues"
   },
   "homepage": "https://github.com/tangledfruit/rx-to-async-iterator#readme",
-  "dependencies": {
-    "rx": "4.0.8"
+  "peerDependencies": {
+    "rx": ">=4.0.7 <5"
   },
   "devDependencies": {
     "chai": "3.5.0",


### PR DESCRIPTION
Without this change, the patches that we make to Rx may or may not be available to client code, depending on a race condition on module loading.

Better to have just one copy of Rx floating around, I think.
