### PR TITLE
Going back to range revisions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "rx": ">=4.0.7 <5"
   },
   "devDependencies": {
-    "chai": "3.5.0",
-    "co": "4.6.0",
-    "co-mocha": "1.1.2",
-    "coveralls": "2.11.9",
-    "istanbul": "0.4.3",
-    "jshint": "2.9.2",
-    "lintspaces-cli": "0.1.1",
-    "mocha": "2.4.5"
+    "chai": "^3.5.0",
+    "co": "^4.6.0",
+    "co-mocha": "^1.1.2",
+    "coveralls": "^2.11.9",
+    "istanbul": "^0.4.3",
+    "jshint": "^2.9.2",
+    "lintspaces-cli": "^0.1.1",
+    "mocha": "^2.4.5"
   },
   "engines": {
     "node": ">=4",


### PR DESCRIPTION
Specifying dependencies via specific revisions seemed like a good idea at the time, but it results in too much signal noise.
